### PR TITLE
🔧 Use hatch-vcs

### DIFF
--- a/packages/document-issue-api/pyproject.toml
+++ b/packages/document-issue-api/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -45,7 +45,8 @@ Issues = "https://github.com/unknown/document-issue-api/issues"
 Source = "https://github.com/unknown/document-issue-api"
 
 [tool.hatch.version]
-path = "src/document_issue_api/__about__.py"
+source = "vcs"
+raw-options = { root = "../.." }
 
 [tool.hatch.envs.lint]
 detached = true

--- a/packages/document-issue-api/src/document_issue_api/__about__.py
+++ b/packages/document-issue-api/src/document_issue_api/__about__.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present U.N. Owen <void@some.where>
-#
-# SPDX-License-Identifier: MIT
-__version__ = "0.1.0"

--- a/packages/document-issue-io/pyproject.toml
+++ b/packages/document-issue-io/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -45,7 +45,8 @@ Issues = "https://github.com/maxfordham/document-issue-io/issues"
 Source = "https://github.com/maxfordham/document-issue/packages/document-issue-io"
 
 [tool.hatch.version]
-path = "src/document_issue_io/__about__.py"
+source = "vcs"
+raw-options = { root = "../.." }
 
 [tool.hatch.envs.default]
 dependencies = ["pytest", "pytest-cov"]

--- a/packages/document-issue-io/src/document_issue_io/__about__.py
+++ b/packages/document-issue-io/src/document_issue_io/__about__.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present J Gunstone <j.gunstone@maxfordham.com>
-#
-# SPDX-License-Identifier: MIT
-__version__ = "0.1.1"

--- a/packages/document-issue/pyproject.toml
+++ b/packages/document-issue/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -38,7 +38,8 @@ Issues = "https://github.com/unknown/document-issue/issues"
 Source = "https://github.com/unknown/document-issue"
 
 [tool.hatch.version]
-path = "src/document_issue/__about__.py"
+source = "vcs"
+raw-options = { root = "../.." }
 
 [tool.hatch.envs.default]
 dependencies = ["pytest", "pytest-cov"]

--- a/packages/document-issue/src/document_issue/__about__.py
+++ b/packages/document-issue/src/document_issue/__about__.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present J Gunstone <j.gunstone@maxfordham.com>
-#
-# SPDX-License-Identifier: MIT
-__version__ = "0.3.1"


### PR DESCRIPTION
Configure the `pyproject.toml` files appropriately to use the version in `.git`