### PR TITLE
🦺 Add `document_type` to Document schema

### DIFF
--- a/packages/document-issue/src/document_issue/enums.py
+++ b/packages/document-issue/src/document_issue/enums.py
@@ -70,7 +70,4 @@ class DocumentTypeEnum(str, Enum):
     es: str = "Equipment Schedule"
     rds: str = "Room Data Schedule"
     prs: str = "Plantroom Schedule"
-    nzc: str = "Net-Zero Carbon Schedule"
-
-
-
+    # nzc: str = "Net-Zero Carbon Schedule"  # TODO: Implement this in the future  # noqa: ERA001

--- a/packages/document-issue/src/document_issue/enums.py
+++ b/packages/document-issue/src/document_issue/enums.py
@@ -64,5 +64,13 @@ class IssueFormatEnum(Enum):
     p = "paper - full size"
     r = "paper - reduced size"
 
+class DocumentTypeEnum(str, Enum):
+    """maps DocumentType codes to string description."""
+
+    es: str = "Equipment Schedule"
+    rds: str = "Room Data Schedule"
+    prs: str = "Plantroom Schedule"
+    nzc: str = "Net-Zero Carbon Schedule"
+
 
 


### PR DESCRIPTION
This is linked to this [issue](https://github.com/maxfordham/digital-schedules/issues/342) which will then be used to map to different PDF generations.